### PR TITLE
fix: support non-toplevel models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning].
 
 ## [Unreleased]
 
+## [0.6.0] - 2024-02-18
+
+- allow help flag at any point.
+    https://sander76.github.io/clipstick/usage.html#help
+
 ## [0.5.1] - 2024-01-09
 
 ### Fixed

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # Usage
 
-Crafting your cli is identical to composing a pydantic class. Toghether with some assumptions this is enough to create a fully working cli tool:
+Crafting your cli is identical to composing a pydantic class. Together with some assumptions this is enough to create a fully working cli tool.
 
 
 ## Positional arguments
@@ -113,7 +113,34 @@ When using subcommands, be aware of the following:
 - `sub_command` as a name is not required. Any name will do.
 - Nesting of subcommands is possible.
 
+## Help
 
+As with all cli applications providing `-h` or `--help` as an argument gives you printed help output. Clipstick (any possibly others) allow this argument to be provided at any point during
+entry.
+
+For example consider the help output of a git cli:
+
+```
+Usage: my-cli-app [Options] [Subcommands]
+
+Clone a git repository.
+
+Options:
+    --url                Url of the git repo. [str] [default = https://mysuperrepo]
+
+Subcommands:
+    clone                Clone a repo.
+    info                 Show information about this repo
+```
+
+Halfway through command entry -you have provided the `--url` flag-
+you have forgotten about the rest. In this case which subcommands are available.
+
+You can now add the `-h` flag (`> m-cli-app --url my_url -h`) and help output will be printed.
+Assuming your shell supports this, you can press up, remove the `-h` flag and continue your entry without losing the arguments you already provided.
+
+Tab completion might be a solution to this problem too, but I have never found it really working:
+For example, positional arguments are not supported or mess with Tab completion for paths.
 
 ## Validators
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "clipstick"
-version = "0.5.1"
+version = "0.6.0"
 description = "A pydantic cli creation tool based on Pydantic models."
 license = "MIT"
 authors = ["Sander Teunissen <s.teunissen@gmail.com>"]

--- a/src/clipstick/_docstring.py
+++ b/src/clipstick/_docstring.py
@@ -1,5 +1,6 @@
 import ast
 import inspect
+import textwrap
 
 from pydantic import BaseModel
 
@@ -7,7 +8,7 @@ from pydantic import BaseModel
 def set_undefined_field_descriptions_from_var_docstrings(
     model: type[BaseModel],
 ) -> None:
-    module = ast.parse(inspect.getsource(model))
+    module = ast.parse(textwrap.dedent(inspect.getsource(model)))
     assert isinstance(module, ast.Module)
     class_def = module.body[0]
     assert isinstance(class_def, ast.ClassDef)

--- a/src/clipstick/_tokens.py
+++ b/src/clipstick/_tokens.py
@@ -19,6 +19,7 @@ from clipstick import _exceptions, _help
 from clipstick._annotations import Short
 
 TPydanticModel = TypeVar("TPydanticModel", bound=BaseModel)
+_HELP_KEYS = ("-h", "--help")
 
 
 class THelp(TypedDict):
@@ -553,16 +554,15 @@ class Command(Generic[TPydanticModel]):
         """
         start_idx = idx
 
-        if _is_help_key(idx, arguments):
-            _help.help(self)
-            sys.exit(0)
-
         values_count = len(arguments)
 
         def _check_arg_or_optional(_idx: int, values: list[str]) -> tuple[bool, int]:
             """Every arg in the values list must match one of the tokens in the model."""
             if values_count == _idx:
                 return False, _idx
+            if values[_idx] in _HELP_KEYS:
+                _help.help(self)
+                sys.exit(0)
             for arg in self.tokens.values():
                 success, _idx = arg.match(_idx, values)
                 if success:
@@ -671,12 +671,3 @@ class Subcommand(Command):
             "type": "",
             "default": "",
         }
-
-
-def _is_help_key(idx, values: list[str]) -> bool:
-    try:
-        if values[idx] in ["-h", "--help"]:
-            return True
-    except IndexError:
-        return False
-    return False

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -91,3 +91,26 @@ Subcommands:
 """
         == capture_output.captured_output
     )
+
+
+def test_help_second_level_partially_completed(capture_output):
+    """The help flag can be given at any time. Even when a command
+    is already partially completed. (like the --url flag in this test.)"""
+    with pytest.raises(SystemExit) as err:
+        capture_output(MyGitModel, ["remote", "--url", "some_url", "-h"])
+    assert err.value.code == 0
+    assert (
+        """
+Usage: my-cli-app remote [Options] [Subcommands]
+
+Clone a git repository.
+
+Options:
+    --url                Url of the git repo. [str] [default = https://mysuperrepo]
+
+Subcommands:
+    clone                Clone a repo.
+    info                 Show information about this repo
+"""
+        == capture_output.captured_output
+    )

--- a/tests/test_parse_docstring.py
+++ b/tests/test_parse_docstring.py
@@ -1,0 +1,44 @@
+from typing import Annotated
+import pytest
+from clipstick._docstring import set_undefined_field_descriptions_from_var_docstrings
+from pydantic import BaseModel, Field
+
+
+class GlobalModel(BaseModel):
+    my_value_docstring: str
+    """Docstring for my_value."""
+
+    my_value_annotation: str = Field(description="Description for my_value.")
+
+
+class SomeClass:
+    class ModelInClass(BaseModel):
+        my_value_docstring: str
+        """Docstring for my_value."""
+
+        my_value_annotation: str = Field(description="Description for my_value.")
+
+
+def some_function():
+    class ModelInFunction(BaseModel):
+        my_value_docstring: str
+        """Docstring for my_value."""
+
+        my_value_annotation: str = Field(description="Description for my_value.")
+
+    return ModelInFunction
+
+
+@pytest.mark.parametrize(
+    "model", [GlobalModel, SomeClass.ModelInClass, some_function()]
+)
+def test_set_field_descriptions_for_var_docstrings(model: type[BaseModel]):
+    set_undefined_field_descriptions_from_var_docstrings(model)
+    assert (
+        model.model_fields["my_value_docstring"].description
+        == "Docstring for my_value."
+    )
+    assert (
+        model.model_fields["my_value_annotation"].description
+        == "Description for my_value."
+    )


### PR DESCRIPTION
Parsing the AST of a model not defined in a module top-level fails with an indentation error. With the new test in this patch:

```
src/clipstick/_docstring.py:10: in set_undefined_field_descriptions_from_var_docstrings
    module = ast.parse(inspect.getsource(model))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

source = '    class ModelInClass(BaseModel):\n        my_value_docstring: str\n        """Docstring for my_value."""\n\n        my_value_annotation: str = Field(description="Description for my_value.")\n'
filename = '<unknown>', mode = 'exec'

    def parse(source, filename='<unknown>', mode='exec', *,
              type_comments=False, feature_version=None):
        """
        Parse the source into an AST node.
        Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
        Pass type_comments=True to get back type comments where the syntax allows.
        """
        flags = PyCF_ONLY_AST
        if type_comments:
            flags |= PyCF_TYPE_COMMENTS
        if isinstance(feature_version, tuple):
            major, minor = feature_version  # Should be a 2-tuple.
            assert major == 3
            feature_version = minor
        elif feature_version is None:
            feature_version = -1
        # Else it should be an int giving the minor version for 3.x.
>       return compile(source, filename, mode, flags,
                       _feature_version=feature_version)
E         File "<unknown>", line 1
E           class ModelInClass(BaseModel):
E       IndentationError: unexpected indent

.../python3.11/ast.py:50: IndentationError
```

The patch uses [`textwrap.dedent`](https://docs.python.org/3/library/textwrap.html#textwrap.dedent) on the model source before passing it to the AST parser.